### PR TITLE
Skip course if we can't get the course ID

### DIFF
--- a/mark-canvas-announcements-as-read.py
+++ b/mark-canvas-announcements-as-read.py
@@ -51,7 +51,13 @@ def mark_announcement_unread(course_id, disc_id):
 
 
 for course in courses.json():
-    course_id = course["id"]
+    try:
+        course_id = course["id"]
+    except TypeError:
+        # Potentially malformed JSON response; skip this one.
+        print(f"Couldn't get info for course {course}. Skipping.")
+        continue
+
     nowtime = datetime.datetime.now().isoformat()
 
     # Retrieve all announcements that have been published in the course


### PR DESCRIPTION
At least one user experiences an error upon trying to fetch a course ID. Think that some Canvas instances may be returning malformed JSON responses (possibly when the user doesn't have permissions to access a course). Because we can't change announcements in those courses anyway, let's consider just skipping them.

Addresses #1.

https://github.com/samueldy/mark-canvas-announcements-as-read/blob/996d78dc0589803fff51588fd299dea125a9f017/mark-canvas-announcements-as-read.py#L53-L54